### PR TITLE
fix: correct a typo in the description of the --skip_mailer flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Options:
                                              # Default: false
    [--skip_javascript]                       # Skip adding javascript (webpacker) to the application
                                              # Default: false
-   [--skip_mailer]                           # Do you want to skip setting up a
+   [--skip_mailer]                           # Do you want to skip setting up a transactional mailer (see --mailer option above)?
                                              # Default: false
    [--skip_pagination]                       # Do you want to skip using pagination with your application?
                                              # Default: false
@@ -178,7 +178,7 @@ Options:
 
 ### Walk-Throughts
 
-* [#](/docs/actiontext.md) Create an application using simple_form and create posts scaffold and admin page that will use ActionText 
+* [#](/docs/actiontext.md) Create an application using simple_form and create posts scaffold and admin page that will use ActionText
 
 ## Gems
 


### PR DESCRIPTION
This commit corrects what appears to be a typo in the documentation for the `--skip_mailer flag`. I did this PR inside of Codespaces and didn't see that it had removed an extra space at the end of line 181 until I had already made the commit, but I am happy to remove that from this change if requested.

I wasn't exactly sure what would be best to put here so I based it on the wording of the other flags. Happy. to adjust as needed.

If anything this commit is to bring awareness to this typo in a more helpful way than just opening an issue. 😀 

Thanks for producing this super cool generator - I am excited to give it a spin!